### PR TITLE
Add branch alias, remove version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ composer require honl/magento2-nl-nl
 
 ### Development install:
 ```BASH
-composer require honl/magento2-nl-nl "dev-master"
+composer require honl/magento2-nl-nl:^1@dev
 ```
 
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
             "email": "paul@h-o.nl"
         }
     ],
-    "version": "1.1.2",
     "require": {
         "php": "~5.5.0|~5.6.0|~7.0.0"
     },
@@ -18,5 +17,10 @@
         "files": [
             "registration.php"
         ]
+    },
+     "extra": {
+        "branch-alias": {
+            "dev-master": "1.1-dev"
+        }
     }
 }


### PR DESCRIPTION
`version` should be omitted when using with github; see https://getcomposer.org/doc/04-schema.md#version

Adding branch alias allows to install `1.1.x@dev` instead of dev-master, which is generally not recommended.