### PR TITLE
Update language.xml

### DIFF
--- a/language.xml
+++ b/language.xml
@@ -5,8 +5,8 @@
   -->
 <language xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../magento/framework/App/Language/package.xsd">
     <code>nl_NL</code>
-    <vendor>Ho</vendor>
-    <package>nl_NL</package>
+    <vendor>ho</vendor>
+    <package>nl_nl</package>
     <sort_order>10</sort_order>
     <!--<use vendor="magento" package="nl_nl"/>-->
 </language>


### PR DESCRIPTION
Fixed a bug where the initialization of the module's language.xml file generates the following error:


Element 'vendor': [facet 'pattern'] The value 'Ho' is not accepted by the pattern '[a-z\-_]+'.
Line: 8

Element 'vendor': 'Ho' is not a valid value of the atomic type 'vendorType'.
Line: 8

Element 'package': [facet 'pattern'] The value 'nl_NL' is not accepted by the pattern '[a-z\-_]+'.
Line: 9

Element 'package': 'nl_NL' is not a valid value of the atomic type 'packageType'.
Line: 9